### PR TITLE
fix: copy over static assets during publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,8 @@ jobs:
         run: go vet ./...
       - name: Run tests
         run: go test -race -vet=off ./...
+      - name: Copy static assets 
+        run: cp -r ui/static dist/static
       - name: Run static site page generator
         run: bin/ssg generate -content="pages" -output="dist"
       - name: Publish to Cloudflare Pages


### PR DESCRIPTION
Static assets aren't coming through during deployment.
I'd previously copied over `static/css` and `/img` directories and forgotten about it :) 
Updating the deploy script to do this is an effective fix for now, but the local `serve` command is left lacking.

Improvements (either bringing copy fuction into the cli app using go libraries, or a wrapper shell script for local dev) are coming shortly.



