### PR TITLE
fix: Update copy task to avoid excessive nesting

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run static site page generator
         run: bin/ssg generate -content="pages" -output="dist"
       - name: Copy static assets 
-        run: mkdir -p dist/static && cp -r ui/static dist/static
+        run: mkdir -p dist/static && cp -r ui/static dist
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@v1
         with:


### PR DESCRIPTION
Static asset directory copying results in a dist/static/static dir. This fix updates the line (again) and fixes it, for realsies this time.